### PR TITLE
Remove --user-lang arg as no longer supported by backend data

### DIFF
--- a/streamer/args.py
+++ b/streamer/args.py
@@ -1,5 +1,6 @@
 import argparse
 
+
 def csv_args(value):
     """Parse a CSV string into a Python list of strings.
 
@@ -21,7 +22,8 @@ def locations_type(value):
     """Conversion and validation for --locations= argument."""
     parsed = csv_args(value)
     if len(parsed) % 4 != 0:
-        raise argparse.ArgumentTypeError('must contain a multiple of four floating-point numbers defining the locations to include.')
+        raise argparse.ArgumentTypeError(
+            'must contain a multiple of four floating-point numbers defining the locations to include.')
     return parsed
 
 
@@ -35,8 +37,9 @@ def duration_type(value):
     Returns # of seconds.
     """
     import re
-    value = value.strip() + ' ' # pad with space which is synonymous with 'S' (seconds).
-    secs = { ' ': 1, 's': 1, 'm': 60, 'h': 3600, 'd': 86400 }
+    # pad with space which is synonymous with 'S' (seconds).
+    value = value.strip() + ' '
+    secs = {' ': 1, 's': 1, 'm': 60, 'h': 3600, 'd': 86400}
     match = re.match("^(?P<val>\d+)(?P<code>[\ssmhd]+)", value.lower())
     if match:
         val = int(match.group('val'))
@@ -48,11 +51,13 @@ def duration_type(value):
             code = code[0]
         return val * secs[code]
     else:
-        raise argparse.ArgumentTypeError('Unexpected duration type "%s".' % value.strip())
+        raise argparse.ArgumentTypeError(
+            'Unexpected duration type "%s".' % value.strip())
 
 
 def parse_command_line(version):
-    parser = argparse.ArgumentParser(description='Twitter Stream dumper v%s' % version)
+    parser = argparse.ArgumentParser(
+        description='Twitter Stream dumper v%s' % version)
 
     parser.add_argument(
         '-f',
@@ -83,7 +88,7 @@ def parse_command_line(version):
         help=r"""query Twitter's geo/search API to find an exact match for provided
          name, which is then converted to a locations bounding box and used as
          the --location parameter."""
-        )
+    )
 
     parser.add_argument(
         '-d',
@@ -108,7 +113,7 @@ def parse_command_line(version):
         default='WARN',
         metavar='log-level',
         help="set log level to one recognized by core logging module.  Default is WARN."
-        )
+    )
 
 #    parser.add_argument(
 #        '-v',
@@ -123,28 +128,25 @@ def parse_command_line(version):
         type=int,
         metavar='seconds',
         help='Report time difference between local system and Twitter stream server time exceeding this number of seconds.'
-        )
+    )
 
     parser.add_argument(
         '-u',
-        '--user-lang',
+        '--tweet-lang',
         type=csv_args,
-        default='en',
+        default=None,
         metavar='language-code',
         help="""BCP-47 language filter(s).  A comma-separate list of language codes.
-        Default is "en", which will include
-        only tweets made by users having English (en) as their profile language.
-        Incoming status user\'s language must match one these languages;
-        if you wish to capture all languages,
-        use -u '*'."""
-        )
+        Default is None, which will include all tweets.
+        """
+    )
 
     parser.add_argument(
         '-n',
         '--no-retweets',
         action='store_true',
         help='don\'t include statuses identified as retweets.'
-        )
+    )
 
     parser.add_argument(
         '-t',
@@ -161,13 +163,13 @@ def parse_command_line(version):
         'track',
         nargs='*',
         help='status keywords to be tracked (optional if --locations provided.)'
-        )
+    )
 
     p = parser.parse_args()
     # HACK: If user specifies wildcard '*' language filter in list,
-    # empty the user_lang member so we don't filter on them later.
+    # empty the tweet_lang member so we don't filter on them later.
     # See: StreamListener.tweet_matchp()
-    if  p.user_lang and '*' in p.user_lang:
-        p.user_lang = []
+    if p.tweet_lang and '*' in p.tweet_lang:
+        p.tweet_lang = []
 
     return p

--- a/streamer/listener.py
+++ b/streamer/listener.py
@@ -59,9 +59,10 @@ class StreamListener(tweepy.StreamListener):
     def on_disconnect(self, stream_data):
         msg = json.loads(stream_data)
         self.logger.warn("Disconnect: code: %d stream_name: %s reason: %s",
-                    utils.resolve_with_default(msg, 'disconnect.code', 0),
-                    utils.resolve_with_default(msg, 'disconnect.stream_name', 'n/a'),
-                    utils.resolve_with_default(msg, 'disconnect.reason', 'n/a'))
+                         utils.resolve_with_default(msg, 'disconnect.code', 0),
+                         utils.resolve_with_default(
+                             msg, 'disconnect.stream_name', 'n/a'),
+                         utils.resolve_with_default(msg, 'disconnect.reason', 'n/a'))
 
     def parse_warning_and_dispatch(self, stream_data):
         try:
@@ -90,7 +91,8 @@ class StreamListener(tweepy.StreamListener):
                             value = utils.resolve_with_default(status, f, None)
                         except AttributeError:
                             if self.opts.terminate_on_error:
-                                self.logger.error("Field '%s' not found in tweet id=%s, terminating." % (f, status.id_str))
+                                self.logger.error(
+                                    "Field '%s' not found in tweet id=%s, terminating." % (f, status.id_str))
                                 # Terminate main loop.
                                 self.running = False
                                 # Terminate read loop.
@@ -120,13 +122,15 @@ class StreamListener(tweepy.StreamListener):
         # necessary.
         if self.opts.report_lag:
             now = datetime.datetime.utcnow()
-            tweepy_status = tweepy.models.Status.parse(self.api, json.loads(stream_data))
+            tweepy_status = tweepy.models.Status.parse(
+                self.api, json.loads(stream_data))
             delta = now - tweepy_status.created_at
             if abs(delta.seconds) > self.opts.report_lag:
                 # TODO: Gather and report stats on time lag.
                 # TODO: Log transitions: lag less than or greater than current
                 # # seconds, rising/falling, etc.
-                self.logger.warn("Tweet time and local time differ by %d seconds", delta.seconds)
+                self.logger.warn(
+                    "Tweet time and local time differ by %d seconds", delta.seconds)
 
     def parse_limit_and_dispatch(self, stream_data):
         return self.on_limit(json.loads(stream_data)['limit']['track'])
@@ -144,13 +148,15 @@ class StreamListener(tweepy.StreamListener):
         if self.opts.no_retweets and self.is_retweet(tweet):
             return False
 
-        if self.opts.user_lang:
-            return tweet.user.lang in self.opts.user_lang
-        else:
-            return True
+        # Check for language match
+        if self.opts.tweet_lang:
+            return tweet.lang in self.opts.tweet_lang
+
+        return True
 
     def on_warning(self, warning):
-        self.logger.warn("Warning: code=%s message=%s" % (warning['code'], warning['message']))
+        self.logger.warn("Warning: code=%s message=%s" %
+                         (warning['code'], warning['message']))
         # If code='FALLING_BEHIND' buffer state is in warning['percent_full']
 
     def on_error(self, status_code):
@@ -168,7 +174,7 @@ class StreamListener(tweepy.StreamListener):
         Return False to stop processing.
         """
         self.logger.warn('on_timeout')
-        return  ## Continue streaming.
+        return  # Continue streaming.
 
     def on_data(self, data):
         if not self.first_message_received:
@@ -176,7 +182,7 @@ class StreamListener(tweepy.StreamListener):
 
         if self.should_stop():
             self.running = False
-            return False # Exit main loop.
+            return False  # Exit main loop.
 
         for r in self.recognizers:
             if r.match(data):
@@ -200,10 +206,11 @@ class StreamListener(tweepy.StreamListener):
                 flag = et >= self.opts.duration
                 if flag:
                     self.logger.debug("Stop requested due to duration limits (et=%d, target=%d seconds).",
-                                 et,
-                                 self.opts.duration)
+                                      et,
+                                      self.opts.duration)
                 return flag
         if self.opts.max_tweets and self.status_count > self.opts.max_tweets:
-            self.logger.debug("Stop requested due to count limits (%d)." % self.opts.max_tweets)
+            self.logger.debug(
+                "Stop requested due to count limits (%d)." % self.opts.max_tweets)
             return True
         return False


### PR DESCRIPTION
We now support `--tweet-lang` instead, which filters/matches against the tweet's language code instead.  This makes more sense anyway.

**Background:** 
Per [this post](https://twittercommunity.com/t/upcoming-changes-to-user-object-and-get-users-suggestions-endpoints/124732), as of May 20, 2019, `user` object returned as part of the tweet data structure will have a `.lang` value of null.

This PR also includes some PEP8 formatting changes in the affected files.